### PR TITLE
Make it more agnostic

### DIFF
--- a/relay-proxy/constants.js
+++ b/relay-proxy/constants.js
@@ -1,7 +1,7 @@
 export const LOCAL_RELAY_URL = (process.env.RELAY_HOST && process.env.RELAY_PORT) 
   ? `ws://${process.env.RELAY_HOST}:${process.env.RELAY_PORT}` 
   : "ws://localhost:3000";
-export const STORE = "./data/store.json";
+export const STORE = process.env.RELAY_DATA_STORE || "./data/store.json";
 export const DISCOVERY_STATUS = {
   DISCOVERING_RELAYS: "discovering relays",
   IDLE: "idle",

--- a/relay-proxy/server.js
+++ b/relay-proxy/server.js
@@ -6,7 +6,7 @@ import RelayManager from "./RelayManager.js";
 
 const app = express();
 const server = createServer(app);
-const port = 80;
+const port = process.env.RELAY_PROXY_PORT || 80;
 
 app.use(express.json());
 

--- a/ui/src/components/ConnectClient.js
+++ b/ui/src/components/ConnectClient.js
@@ -1,3 +1,5 @@
+const showParagraph = process.env.REACT_APP_OFFICIAL !== "false";
+
 export default function ConnectClientCard({ relayPort }) {
   return (
     <div className="pt-5 px-10 pb-8">
@@ -11,33 +13,35 @@ export default function ConnectClientCard({ relayPort }) {
             relay for seamless backup of all Nostr activity. In Damus, add your
             Relay URL via Settings {">"} Relays.
           </p>
-          <p className="text-slate-800 dark:text-slate-400 text-xs mt-4 mb-6">
-            Tip: Install{" "}
-            <a
-              href={`${window.location.protocol}//${window.location.hostname}/app-store/tailscale`}
-              target="_blank"
-              className="underline underline-offset-2"
-              rel="noreferrer"
-            >
-              Tailscale
-            </a>{" "}
-            on your Umbrel and your devices for an uninterrupted connection
-            between your clients and your relay, even when you&apos;re away from
-            your home network. Enable Tailscale&apos;s{" "}
-            <a
-              href="https://tailscale.com/kb/1081/magicdns"
-              target="_blank"
-              className="underline underline-offset-2"
-              rel="noreferrer"
-            >
-              MagicDNS
-            </a>{" "}
-            and use{" "}
-            <span className="font-mono underline decoration-dashed underline-offset-4">
-              ws://umbrel:{relayPort}
-            </span>{" "}
-            as your Relay URL.
-          </p>
+          {showParagraph && (
+            <p className="text-slate-800 dark:text-slate-400 text-xs mt-4 mb-6">
+              Tip: Install{" "}
+              <a
+                href={`${window.location.protocol}//${window.location.hostname}/app-store/tailscale`}
+                target="_blank"
+                className="underline underline-offset-2"
+                rel="noreferrer"
+              >
+                Tailscale
+              </a>{" "}
+              on your Umbrel and your devices for an uninterrupted connection
+              between your clients and your relay, even when you&apos;re away
+              from your home network. Enable Tailscale&apos;s{" "}
+              <a
+                href="https://tailscale.com/kb/1081/magicdns"
+                target="_blank"
+                className="underline underline-offset-2"
+                rel="noreferrer"
+              >
+                MagicDNS
+              </a>{" "}
+              and use{" "}
+              <span className="font-mono underline decoration-dashed underline-offset-4">
+                ws://umbrel:{relayPort}
+              </span>{" "}
+              as your Relay URL.
+            </p>
+          )}
           <hr className="opacity-90 px-6 mt-4 mb-5 dark:opacity-10" />
         </div>
       </div>


### PR DESCRIPTION
Umbrel build process will be essentially the same, but others can personalize more her builds.

`RELAY_PROXY_PORT` and `RELAY_DATA_STORE` does the evident.

When `REACT_APP_OFFICIAL` isn't set or set to `true` it shows the default `<p>`, when set to `false` it doesn't appear.

```sh
cd ./ui
npm ci
REACT_APP_OFFICIAL=false npm run build
```

![image](https://github.com/user-attachments/assets/d64f1bdd-cedd-4e12-98b8-4079aa45524b)
